### PR TITLE
Fix types of sql_query_response schema

### DIFF
--- a/base_operations.yaml
+++ b/base_operations.yaml
@@ -331,14 +331,11 @@ components:
       type: object
       properties:
         metadata:
-          type: object
-          additionalProperties: true
+          type: array
         results:
-          type: object
-          additionalProperties: true
+          type: array
         success:
-          type: string
-          description: success or error message
+          type: boolean
       example:
         metadata:
           - key: "0000"

--- a/base_operations_deprecated.yaml
+++ b/base_operations_deprecated.yaml
@@ -310,12 +310,10 @@ components:
       type: object
       properties:
         metadata:
-          type: object
-          additionalProperties: true
+          type: array
           # $ref: "#/components/schemas/base_metadata"
         results:
-          type: object
-          additionalProperties: true
+          type: array
         success:
           type: boolean
       example:


### PR DESCRIPTION
Changes should be pretty clear, the example even shows arrays and the boolean being returned. The fix prevents response schema violation errors.

I checked the history and some parts were changed by https://github.com/seatable/openapi/commit/4f8591404f5edbdcbefcdd75b91884371cbee5b6, but then reversed by https://github.com/seatable/openapi/commit/d80c854c18078cd0236503588388c512bff8c2cd :shrug: 